### PR TITLE
check packages installed on Debian with apt

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,10 @@
 #lang info
 (define collection "machine-check")
-(define deps '("base" "rackunit-lib"))
+(define deps 
+  '("base"
+    "rackunit-lib"
+    "https://github.com/vdloo/detect-os-release.git"
+    ))
 (define build-deps '())
 (define pkg-desc "Write unit tests in Racket to verify if the state of your machine is what you expect.")
 (define version "0.1")

--- a/machine-check/test/machine-check/test_get_packages_installed.rkt
+++ b/machine-check/test/machine-check/test_get_packages_installed.rkt
@@ -9,14 +9,61 @@
   (define check-tests
     (test-suite
       "Testsuite for machine-check/machine-check.rkt -> get-packages-installed"
-      (test-case
-        "Test that get-packages-installed calls check-output with pacman as argument"
-        (define mock-check-output 
-	  (λ (command argument)
-	     (check-equal? command "/usr/bin/pacman")
-	     (check-equal? argument "-Qq")))
 
-	(get-packages-installed #:check-output-with mock-check-output))
+      (test-case
+        "Test that get-packages-installed calls check-output with pacman on Arch Linux"
+        (define mock-detect-os-with
+          (λ ()
+             "arch"))
+        (define mock-check-output 
+          (λ (arguments)
+             (check-equal? arguments '("/usr/bin/pacman" "-Qq"))))
+
+        (get-packages-installed 
+          #:detect-os-with mock-detect-os-with
+          #:check-output-with mock-check-output))
+
+      (test-case
+        "Test that get-packages-installed calls check-output with apt on Debian"
+        (define mock-detect-os-with
+          (λ ()
+             "debian"))
+        (define mock-check-output 
+          (λ (arguments)
+             (check-equal? arguments '("/usr/bin/dpkg-query" "-f" "'${binary:Package}\n'" "-W"))))
+
+        (get-packages-installed 
+          #:detect-os-with mock-detect-os-with
+          #:check-output-with mock-check-output))
+
+      (test-case
+        "Test that get-packages-installed calls check-output with apt on Ubuntu"
+        (define mock-detect-os-with
+          (λ ()
+             "ubuntu"))
+        (define mock-check-output 
+          (λ (arguments)
+             (check-equal? arguments '("/usr/bin/dpkg-query" "-f" "'${binary:Package}\n'" "-W"))))
+
+        (get-packages-installed 
+          #:detect-os-with mock-detect-os-with
+          #:check-output-with mock-check-output))
+
+      (test-case
+        "Test that get-packages-installed raises if unsupported distro"
+        (define mock-detect-os-with
+          (λ ()
+             "fedora"))
+        (define mock-check-output 
+          (λ (arguments)
+             (check-true #f)))  ; check-output should not be called in this test-case
+
+        (check-exn exn:fail:contract?
+          (λ ()
+            (get-packages-installed 
+              #:detect-os-with mock-detect-os-with
+              #:check-output-with mock-check-output))))
+
       ))
 
 (run-tests check-tests))


### PR DESCRIPTION
Use dpkg-query on Debian (and Ubuntu) to list installed packages:
```
$ dpkg-query -f '${binary:Package}\n' -W | head -n 10
adduser
adwaita-icon-theme
apparmor
apt
apt-utils
aptitude
aptitude-common
base-files
base-passwd
bash
```