### PR TITLE
fix missing import machine-check.rkt

### DIFF
--- a/machine-check/machine-check.rkt
+++ b/machine-check/machine-check.rkt
@@ -5,6 +5,7 @@
 (require racket/string)
 (require racket/port)
 (require racket/function)
+(require racket/file)
 (require rackunit)
 (require detect-os-release)
 


### PR DESCRIPTION
file->lines comes from racket/file, see https://docs.racket-lang.org/reference/Filesystem.html#%28mod-path._racket%2Ffile%29