### PR TITLE
check-file-mode test has realistic values

### DIFF
--- a/machine-check/test/machine-check/test_check_file_mode.rkt
+++ b/machine-check/test/machine-check/test_check_file_mode.rkt
@@ -18,9 +18,9 @@
              (check-equal? path "/tmp/some-file-somewhere")
              (check-equal? mustexist #f)
              #t))
-        (define mock-file-or-directory-permissions-with (λ (path mode) 755))
+        (define mock-file-or-directory-permissions-with (λ (path mode) 493))
 
-        (check-file-mode "/tmp/some-file-somewhere" 755
+        (check-file-mode "/tmp/some-file-somewhere" 493
           #:file-or-directory-type-with mock-file-or-directory-type-with
           #:file-or-directory-permissions-with mock-file-or-directory-permissions-with))
 
@@ -31,9 +31,9 @@
           (λ (path mode) 
              (check-equal? path "/tmp/some-file-somewhere")
              (check-equal? mode 'bits)
-             755))
+             493))
 
-        (check-file-mode "/tmp/some-file-somewhere" 755
+        (check-file-mode "/tmp/some-file-somewhere" 493
           #:file-or-directory-type-with mock-file-or-directory-type-with
           #:file-or-directory-permissions-with mock-file-or-directory-permissions-with))
 
@@ -43,7 +43,7 @@
 
         (check-exn exn:fail?
           (λ ()
-          (check-file-mode "/tmp/some-file-somewhere" 755
+          (check-file-mode "/tmp/some-file-somewhere" 493
             #:file-or-directory-type-with mock-file-or-directory-type-with))))
        ))
 (run-tests check-tests))


### PR DESCRIPTION
see https://github.com/vdloo/homelabmanager/pull/66/files, it's not the octal mode you'd expect.

> If 'bits is supplied as the second argument, the result is a platform-specific integer encoding of the file or directory properties (mostly permissions), and the result is independent of the current user and group. The lowest nine bits of the encoding are somewhat portable, reflecting permissions for the file or directory’s owner, members of the file or directory’s group, or other users:

see https://docs.racket-lang.org/reference/Filesystem.html#%28def._%28%28quote._~23~25kernel%29._file-or-directory-permissions%29%29