### PR TITLE
better failure message check-file-contains

### DIFF
--- a/machine-check/machine-check.rkt
+++ b/machine-check/machine-check.rkt
@@ -59,17 +59,24 @@
          (fail (format "No such path: ~a" path)))))
 
 (define inner-check-file-contains
-  (λ (assert-function)
+  (λ (assert-function failure-message)
     (λ (path should-contain
         #:file->string-with [file->string file->string])
        (assert-function
          (string-contains?
            (file->string path)
-           should-contain)))))
+           should-contain)
+         (format failure-message path should-contain)))))
 
-(define check-file-contains (inner-check-file-contains check-true))
+(define check-file-contains
+  (inner-check-file-contains
+    check-true
+    "File ~a did not contain '~a' like we expected"))
 
-(define check-file-does-not-contain (inner-check-file-contains check-false))
+(define check-file-does-not-contain
+  (inner-check-file-contains
+    check-false
+    "File ~a unexpectedly contained '~a'"))
 
 (define check-package-installed
   (λ (package-name)


### PR DESCRIPTION
looks like:
```
FAILURE
name:       check-true
location:   .../machine-check/machine-check.rkt:73:4
params:     '(#f)
message:
  "File /usr/local/bin/clone_development_projects.sh did not contain 'github.com/vdloo/homelabmanager' like we expected"
--------------------
--------------------
FAILURE
name:       check-false
location:   .../machine-check/machine-check.rkt:78:4
params:     '(#t)
message:
  "File /usr/local/bin/configure_vim.sh unexpectedly contained 'UNPRIVILEGED_USER=root'"
```