### PR TITLE
restructure imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 compiled/
 doc/
 out/
+checks-to-perform/*.rkt

--- a/checks-to-perform/README.md
+++ b/checks-to-perform/README.md
@@ -1,0 +1,4 @@
+Checks to perform
+=================
+
+Place your checks here. See examples/ for an example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,21 +1,25 @@
 # Examples
 
-A directory with examples of how to structure your /srv/machine-check directory.
+A directory with examples of how to structure your checks-to-perform directory.
 
-To use these examples do the following:
+First configure your checks in the `checks-to-perform` directory.
+
+Each file must be named the same as the `perform-*-checks` function it provides.
+
+So a file named `core.rkt` should `(provide perform-core-checks` and `(define perform-core-checks ...)` etc.
+
+First copy a test example file to `checks-to-perform`:
 ```
-sudo mkdir -p /srv/machine-check
-sudo chown youruser.youruser /srv/machine-check
-ln -s examples/simple/main.rkt /srv/machine-check/main.rkt
+$ cp examples/simple/main.rkt.example checks-to-perform/main.rkt
 ```
 
 Then run:
 ```
-$ machine-check  # or ./main.rkt
+$ make run  # or ./main.rkt or machine-check
 --------------------
 FAILURE
 name:       check-false
-location:   machine-check/machine-check.rkt:31:5
+location:   machine-check/check-helpers.rkt:83:5
 params:     '(#t)
-message:    "Package 'somenotinstalledpackage' was not found installed"
+message:    "Package 'some-package' was not found installed"
 ```

--- a/examples/multiple-files/core.rkt.example
+++ b/examples/multiple-files/core.rkt.example
@@ -1,9 +1,8 @@
 #lang racket/base
 
 (require "../machine-check/check-helpers.rkt")
-(provide perform-main-checks)
+(provide perform-core-checks)
 
-(define perform-main-checks
+(define perform-core-checks
   (λ ()
     (check-package-installed "some-package")))
-

--- a/examples/multiple-files/main.rkt.example
+++ b/examples/multiple-files/main.rkt.example
@@ -1,4 +1,0 @@
-; A multiple file example of some checks you could run
-
-(include "package.rkt")
-(include "packages.rkt")

--- a/examples/multiple-files/package.rkt.example
+++ b/examples/multiple-files/package.rkt.example
@@ -1,4 +1,0 @@
-; check with check-package-installed
-
-(check-package-installed "make")  ; is installed
-(check-package-installed "somenotinstalledpackage")  ; not installed

--- a/examples/multiple-files/packages.rkt.example
+++ b/examples/multiple-files/packages.rkt.example
@@ -1,7 +1,0 @@
-; check with check-packages-installed
-
-(check-packages-installed
- (list 
-   "make"  ; is installed
-   "somenotinstalledpackage" ; not installed
-   ))

--- a/examples/multiple-files/shellserver.rkt.example
+++ b/examples/multiple-files/shellserver.rkt.example
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(require "../machine-check/check-helpers.rkt")
+(provide perform-shellserver-checks)
+
+(define perform-shellserver-checks
+  (λ ()
+    (check-package-installed "some-other-package")))

--- a/info.rkt
+++ b/info.rkt
@@ -3,6 +3,7 @@
 (define deps 
   '("base"
     "rackunit-lib"
+    "reprovide-lang-lib"
     "https://github.com/vdloo/detect-os-release.git"
     ))
 (define build-deps '())

--- a/machine-check/check-helpers.rkt
+++ b/machine-check/check-helpers.rkt
@@ -1,0 +1,91 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+(require racket/include)
+(require racket/string)
+(require racket/port)
+(require racket/function)
+(require racket/file)
+(require rackunit)
+(require detect-os-release)
+
+(provide check-output)
+(provide get-packages-installed)
+(provide check-package-installed)
+(provide check-packages-installed)
+(provide check-file-mode)
+(provide check-file-contains)
+(provide check-file-does-not-contain)
+
+(define check-output
+  (λ (arguments)
+    (define-values (sp out in err)
+      (apply (curry subprocess #f #f #f) arguments))
+    (subprocess-wait sp)
+    (define lines (string-split (port->string out) "\n"))
+    (close-input-port out)
+    (close-output-port in)
+    (close-input-port err)
+    lines))
+
+(define get-packages-installed
+  (λ (#:detect-os-with [detect-os detect-os]
+      #:check-output-with [check-output check-output])
+     (let ((os-id (detect-os))
+           (arch-command '("/usr/bin/pacman" "-Qq"))
+           (debian-like-command '("/usr/bin/dpkg-query" "-f" "${binary:Package}\n" "-W"))
+           (redhat-like-command '("/usr/bin/rpm" "-qa" "--qf" "'%{NAME}\n'")))
+
+       (check-output
+         (cond
+           [(equal? "arch" os-id) arch-command]
+           [(equal? "debian" os-id) debian-like-command]
+           [(equal? "ubuntu" os-id) debian-like-command]
+           [(equal? "rhel" os-id) redhat-like-command]
+           [(equal? "centos" os-id) redhat-like-command]
+           [(equal? "fedora" os-id) redhat-like-command]
+           [else (raise-arguments-error 
+                   'os-not-supported 
+                   (format "Your OS ~a is currently not supported by machine-check" os-id))])))))
+
+(define check-file-mode
+  (λ (path mode
+      #:file-or-directory-type-with [file-or-directory-type file-or-directory-type]
+      #:file-or-directory-permissions-with [file-or-directory-permissions file-or-directory-permissions])
+     (if (file-or-directory-type path #f)
+         ((λ ()
+           (check-equal? (file-or-directory-permissions path 'bits) mode) 
+           (display ".")))
+         (fail (format "No such path: ~a" path)))))
+
+(define inner-check-file-contains
+  (λ (assert-function failure-message)
+    (λ (path should-contain
+        #:file->string-with [file->string file->string])
+       (assert-function
+         (string-contains?
+           (file->string path)
+           should-contain)
+         (format failure-message path should-contain)))))
+
+(define check-file-contains
+  (inner-check-file-contains
+    check-true
+    "File ~a did not contain '~a' like we expected"))
+
+(define check-file-does-not-contain
+  (inner-check-file-contains
+    check-false
+    "File ~a unexpectedly contained '~a'"))
+
+(define check-package-installed
+  (λ (package-name)
+     (check-false (not (member package-name (get-packages-installed)))
+         (format "Package '~a' was not found installed" package-name))
+     (display ".")))
+
+(define check-packages-installed
+  (λ (package-names)
+     (for-each
+       check-package-installed
+       package-names)))

--- a/machine-check/check-importer.rkt
+++ b/machine-check/check-importer.rkt
@@ -1,0 +1,37 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+(require racket/string)
+(require reprovide/require-transformer/glob-in)
+(require (glob-in "../checks-to-perform/*.rkt"))
+
+(provide perform-checks)
+
+(define get-module-names
+  (λ ()
+     (map (λ (p) (string-trim p ".rkt"))
+       (filter (λ (p) (string-suffix? p ".rkt"))
+         (map
+           path->string 
+           (directory-list "checks-to-perform"))))))
+
+
+(define perform-checks
+  (λ ()
+     (map 
+       ; See this stackoverflow comment about evaluating
+       ; strings to procedures in Racket. Note that this
+       ; is REALLY dangerous and shouldn't be done in any
+       ; production grade code. But this is Lisp after all
+       ; and I want to treat code as data and data as code.
+       ; https://stackoverflow.com/a/29461124/4158804
+       (λ
+         (s) 
+         ((eval 
+            (string->symbol s) 
+            (variable-reference->namespace 
+              (#%variable-reference)))))
+       (map 
+         (λ (n) (format "perform-~a-checks" n))
+         (get-module-names)))
+     (void)))

--- a/machine-check/machine-check.rkt
+++ b/machine-check/machine-check.rkt
@@ -2,106 +2,26 @@
 #lang racket/base
 
 (require racket/include)
-(require racket/string)
-(require racket/port)
-(require racket/function)
-(require racket/file)
 (require rackunit)
-(require detect-os-release)
+
+(require "check-importer.rkt")
 
 (provide machine-check)
-(provide get-packages-installed)
-(provide check-file-mode)
-(provide check-file-contains)
-(provide check-file-does-not-contain)
 
 (define error-count 0)
-
-(define check-output
-  (λ (arguments)
-    (define-values (sp out in err)
-      (apply (curry subprocess #f #f #f) arguments))
-    (subprocess-wait sp)
-    (define lines (string-split (port->string out) "\n"))
-    (close-input-port out)
-    (close-output-port in)
-    (close-input-port err)
-    lines))
-
-(define get-packages-installed
-  (λ (#:detect-os-with [detect-os detect-os]
-      #:check-output-with [check-output check-output])
-     (let ((os-id (detect-os))
-           (arch-command '("/usr/bin/pacman" "-Qq"))
-           (debian-like-command '("/usr/bin/dpkg-query" "-f" "${binary:Package}\n" "-W"))
-           (redhat-like-command '("/usr/bin/rpm" "-qa" "--qf" "'%{NAME}\n'")))
-
-       (check-output
-         (cond
-           [(equal? "arch" os-id) arch-command]
-           [(equal? "debian" os-id) debian-like-command]
-           [(equal? "ubuntu" os-id) debian-like-command]
-           [(equal? "rhel" os-id) redhat-like-command]
-           [(equal? "centos" os-id) redhat-like-command]
-           [(equal? "fedora" os-id) redhat-like-command]
-           [else (raise-arguments-error 
-                   'os-not-supported 
-                   (format "Your OS ~a is currently not supported by machine-check" os-id))])))))
-
-(define check-file-mode
-  (λ (path mode
-      #:file-or-directory-type-with [file-or-directory-type file-or-directory-type]
-      #:file-or-directory-permissions-with [file-or-directory-permissions file-or-directory-permissions])
-     (if (file-or-directory-type path #f)
-         ((λ ()
-           (check-equal? (file-or-directory-permissions path 'bits) mode) 
-           (display ".")))
-         (fail (format "No such path: ~a" path)))))
-
-(define inner-check-file-contains
-  (λ (assert-function failure-message)
-    (λ (path should-contain
-        #:file->string-with [file->string file->string])
-       (assert-function
-         (string-contains?
-           (file->string path)
-           should-contain)
-         (format failure-message path should-contain)))))
-
-(define check-file-contains
-  (inner-check-file-contains
-    check-true
-    "File ~a did not contain '~a' like we expected"))
-
-(define check-file-does-not-contain
-  (inner-check-file-contains
-    check-false
-    "File ~a unexpectedly contained '~a'"))
-
-(define check-package-installed
-  (λ (package-name)
-     (check-false (not (member package-name (get-packages-installed)))
-         (format "Package '~a' was not found installed" package-name))
-     (display ".")))
-
-(define check-packages-installed
-  (λ (package-names)
-     (for-each
-       check-package-installed
-       package-names)))
-
-(define perform-checks
-  (λ () (include (file "/srv/machine-check/main.rkt"))))
 
 (define machine-check
   (λ (args)
      (begin
        (define old-around (current-check-around))
        (define (count-errors thunk)
-         (with-handlers ([exn:test:check? (λ (e) (set! error-count (+ 1 error-count))
-                                            (old-around thunk))])
+         (with-handlers
+           ([exn:test:check?
+              (λ (e)
+               (set! error-count (+ 1 error-count))
+               (old-around thunk))])
            (thunk)))
        (parameterize ([current-check-around count-errors])
-       (perform-checks)
+         (perform-checks)
        (if (eq? error-count 0) (displayln "\nAll tests pass!") '())
        (exit (min error-count 1))))))

--- a/machine-check/test/check-helpers/test_check_file_contains.rkt
+++ b/machine-check/test/check-helpers/test_check_file_contains.rkt
@@ -4,7 +4,7 @@
 (require rackunit/text-ui)
 (require racket/file)
 
-(require "../../machine-check.rkt")
+(require "../../check-helpers.rkt")
 
 (module+ test
   (define check-tests

--- a/machine-check/test/check-helpers/test_check_file_does_not_contain.rkt
+++ b/machine-check/test/check-helpers/test_check_file_does_not_contain.rkt
@@ -4,7 +4,7 @@
 (require rackunit/text-ui)
 (require racket/file)
 
-(require "../../machine-check.rkt")
+(require "../../check-helpers.rkt")
 
 (module+ test
   (define check-tests

--- a/machine-check/test/check-helpers/test_check_file_mode.rkt
+++ b/machine-check/test/check-helpers/test_check_file_mode.rkt
@@ -4,7 +4,7 @@
 (require rackunit/text-ui)
 (require racket/file)
 
-(require "../../machine-check.rkt")
+(require "../../check-helpers.rkt")
 
 (module+ test
   (define check-tests

--- a/machine-check/test/check-helpers/test_get_packages_installed.rkt
+++ b/machine-check/test/check-helpers/test_get_packages_installed.rkt
@@ -3,7 +3,7 @@
 (require rackunit)
 (require rackunit/text-ui)
 
-(require "../../machine-check.rkt")
+(require "../../check-helpers.rkt")
 
 (module+ test
   (define check-tests


### PR DESCRIPTION
do not use (include but use reprovide/require-transformer/glob-in to
include all .rkt files from a directory and execute procedures provided
by them based on a certain naming convention.